### PR TITLE
Fix: Removing $verbose parameter from Install-WMF3Hotfix.ps1

### DIFF
--- a/scripts/Install-WMF3Hotfix.ps1
+++ b/scripts/Install-WMF3Hotfix.ps1
@@ -42,9 +42,7 @@ details.
 #>
 
 [CmdletBinding()]
-Param(
-    [switch]$verbose
-)
+Param()
 
 $ErrorActionPreference = "Stop"
 if ($verbose) {


### PR DESCRIPTION
Executing Install-WMF3Hotfix.ps1 script fails with the following error:

> A parameter with the name 'Verbose' was defined multiple times for the command.
>     + CategoryInfo          : MetadataError: (:) [], ParentContainsErrorRecordException
>     + FullyQualifiedErrorId : ParameterNameAlreadyExistsForCommand

I am no expert, but I guess defining $verbose parameter is redundant because of CmdletBinding() sentence. According to [this link](https://blogs.technet.microsoft.com/poshchap/2014/10/24/scripting-tips-and-tricks-cmdletbinding/), CmdletBinding() in its simplest form already provides -Verbose parameter support.