### PR TITLE
Upgraded to Fedora 28 and use correct OS version code

### DIFF
--- a/scripts/Install-WMF3Hotfix.ps1
+++ b/scripts/Install-WMF3Hotfix.ps1
@@ -105,7 +105,7 @@ if ($hotfix_installed -ne $null) {
 if (-not (Test-Path -Path $tmp_dir)) {
     New-Item -Path $tmp_dir -ItemType Directory > $null
 }
-$os_version = [Environment]::OSVersion.Version
+$os_version = [Version](Get-Item -Path "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
 $host_string = "$($os_version.Major).$($os_version.Minor)-$($env:PROCESSOR_ARCHITECTURE)"
 switch($host_string) {
     "6.0-x86" {
@@ -127,6 +127,7 @@ switch($host_string) {
         $url = "https://hotfixv4.trafficmanager.net/Windows%208%20RTM/nosp/Fix452763/9200/free/463941_intl_x64_zip.exe"
     }
 }
+
 $filename = $url.Split("/")[-1]
 $compressed_file = "$tmp_dir\$($filename).zip"
 Download-File -url $url -path $compressed_file
@@ -136,6 +137,7 @@ if ($file -eq $null) {
     Write-Error -Message "unable to find extracted msu file for hotfix KB"
     exit 1
 }
+
 $exit_code = Run-Process -executable $file.FullName -arguments "/quiet /norestart"
 if ($exit_code -eq 3010) {
     Write-Verbose "need to restart computer after hotfix $kb install"

--- a/scripts/Upgrade-PowerShell.ps1
+++ b/scripts/Upgrade-PowerShell.ps1
@@ -241,7 +241,7 @@ if ($current_ps_version -eq [version]$version) {
     exit 0
 }
 
-$os_version = [System.Environment]::OSVersion.Version
+$os_version = [Version](Get-Item -Path "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
 $architecture = $env:PROCESSOR_ARCHITECTURE
 if ($architecture -eq "AMD64") {
     $architecture = "x64"

--- a/vagrant-linux/inventory.yml
+++ b/vagrant-linux/inventory.yml
@@ -13,7 +13,7 @@ all:
           ansible_package_name: 'yum'
         FEDORA27:
           ansible_host: 192.168.56.23
-          vagrant_box: generic/fedora27
+          vagrant_box: generic/fedora28
           ansible_package_name: 'dnf'
   vars:
     man_user_setup_user: ansible


### PR DESCRIPTION
Stop using `[System.Environment]::OSVersion.Version` as it will report the wrong version if using an un manifested application. According to [this](https://docs.microsoft.com/en-us/windows/desktop/SysInfo/getting-the-system-version), the recommended way to get the full version number for the OS

> 
To obtain the full version number for the operating system, call the GetFileVersionInfo function on one of the system DLLs, such as Kernel32.dll, then call VerQueryValue to obtain the \\StringFileInfo\\<lang><codepage>\\ProductVersion subblock of the file version information.

This translates to `[Version](Get-Item -Path "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion` in PowerShell.

One final change also updates the Fedora vagrant box to 28.

Fixes https://github.com/jborean93/ansible-windows/issues/7
Fixes https://github.com/jborean93/ansible-windows/issues/8
Fixes https://github.com/jborean93/ansible-windows/issues/9