### PR TITLE
Add scripts for installing Windows Management Framework 5

### DIFF
--- a/scripts/Install-WMF3Hotfix.ps1
+++ b/scripts/Install-WMF3Hotfix.ps1
@@ -35,14 +35,20 @@ See https://github.com/jborean93/ansible-windows/tree/master/scripts for more
 details.
 .PARAMETER Verbose
     [switch] - Whether to display Verbose logs on the console
+.PARAMETER AutoReboot
+    [switch] - Enables reboot if needed, does not ask for confirmation
 .EXAMPLE
     powershell.exe -ExecutionPolicy ByPass -File Install-WMF3Hotfix.ps1
 .EXAMPLE
     powershell.exe -ExecutionPolicy ByPass -File Install-WMF3Hotfix.ps1 -Verbose
+.EXAMPLE
+    powershell.exe -ExecutionPolicy ByPass -File Install-WMF3Hotfix.ps1 -Verbose -AutoReboot
 #>
 
 [CmdletBinding()]
-Param()
+Param(
+    [switch]$AutoReboot
+)
 
 $ErrorActionPreference = "Stop"
 if ($verbose) {
@@ -143,7 +149,14 @@ if ($file -eq $null) {
 $exit_code = Run-Process -executable $file.FullName -arguments "/quiet /norestart"
 if ($exit_code -eq 3010) {
     Write-Verbose "need to restart computer after hotfix $kb install"
-    Restart-Computer -Confirm
+    if ($AutoReboot) {
+        Write-Verbose "performing autoreboot"
+        Restart-Computer -Confirm:$false
+    }
+    else {
+        Write-Verbose "getting user confirmation to reboot"
+        Restart-Computer -Confirm
+    }
 } elseif ($exit_code -ne 0) {
     Write-Error -Message "failed to install hotfix $($kb): exit code $exit_code"
 } else {

--- a/scripts/Install-WMF5.ps1
+++ b/scripts/Install-WMF5.ps1
@@ -1,0 +1,245 @@
+#Requires -Version 3.0
+<#PSScriptInfo
+.VERSION 1.0
+.GUID 477eeb5d-9300-47cf-8590-575bb0a6e0ba
+.AUTHOR
+Junaid Ali <mailtojunaid@gmail.com>
+.COPYRIGHT
+Syed Junaid Ali 2019
+.TAGS
+PowerShell,Ansible,WinRM,WMF,Hotfix
+.LICENSEURI https://github.com/junaidali/ansible-windows/blob/master/LICENSE
+.PROJECTURI https://github.com/junaidali/ansible-windows
+.RELEASENOTES
+Version 1.0: 2019-07-19
+    Installs Windows Management Framework 5.1
+#>
+
+<#
+.DESCRIPTION
+The script will install Windows Remote Management Framework 5.1. It can be used on installed on Windows 7, Windows 8.1, Windows Server 2008 R2, 2012, and 2012 R2
+The script will;
+1. Detect if running on PS version 3.0 and exit if it is not
+2. Check if WMF 5.1 is already installed and exit if it is
+3. Download the setup files from Microsoft server's based on the OS version
+4. Extract the .msu file from the downloaded zip file (if applicable)
+5. Install the .msu silently
+6. Detect if a reboot is required check confirmation, auto reboot or skip reboot based on user choice
+
+.PARAMETER Verbose
+[switch] - Whether to display Verbose logs on the console
+.PARAMETER AutoReboot
+[switch] - Enables reboot if needed, does not ask for confirmation
+.PARAMETER SkipReboot
+[switch] - Skips system reboot, if it is managed by external process
+.PARAMETER LogFile
+[string] - Path to the log file. If not specified defaults to Install-WMF5.ps1.log within the script directory
+.EXAMPLE
+powershell.exe -ExecutionPolicy ByPass -File Install-WMF5.ps1
+.EXAMPLE
+powershell.exe -ExecutionPolicy ByPass -File Install-WMF5.ps1 -Verbose
+.EXAMPLE
+powershell.exe -ExecutionPolicy ByPass -File Install-WMF5.ps1 -Verbose -AutoReboot
+.EXAMPLE
+powershell.exe -ExecutionPolicy ByPass -File Install-WMF5.ps1 -Verbose -SkipReboot
+.EXAMPLE
+powershell.exe -ExecutionPolicy ByPass -File Install-WMF5.ps1 -Verbose -LogFile C:\Temp\wmf5.log
+#>
+
+[CmdletBinding()]
+Param(
+    [switch]$AutoReboot,
+    [switch]$SkipReboot,
+    [string]$LogFile
+)
+
+$ErrorActionPreference = "Stop"
+if ($verbose) {
+    $VerbosePreference = "Continue"
+}
+
+# -- Constants
+$DEBUG = "DEBUG"
+$WARN = "WARNING"
+$ERR = "ERROR"
+
+# --- Function Declarations
+function LogMessage() {
+    param ([string]$MessageType, [string]$Message)
+    $timestamp = "[{0:MM/dd/yy} {0:HH:mm:ss}]" -f (Get-Date)
+    Write-Output "$timestamp $MessageType $Message" | Out-File -FilePath $scriptLog -Append   
+    if ($MessageType -eq $ERR) {
+        Write-Error "$timestamp $MessageType $Message" 
+    } 
+    else {
+        Write-Verbose "$timestamp $MessageType $Message"   
+    }
+    
+}
+
+# Imported from https://github.com/jborean93/ansible-windows/tree/master/scripts
+Function Run-Process($executable, $arguments) {
+    $process = New-Object -TypeName System.Diagnostics.Process
+    $psi = $process.StartInfo
+    $psi.FileName = $executable
+    $psi.Arguments = $arguments
+    LogMessage -MessageType $DEBUG -Message "starting new process '$executable $arguments'"
+    $process.Start() | Out-Null
+
+    $process.WaitForExit() | Out-Null
+    $exit_code = $process.ExitCode
+    LogMessage -MessageType $DEBUG -Message "process completed with exit code '$exit_code'"
+
+    return $exit_code
+}
+
+# Imported from https://github.com/jborean93/ansible-windows/tree/master/scripts
+Function Download-File($url, $path) {
+    LogMessage -MessageType $DEBUG -Message "downloading url '$url' to '$path'"
+    $client = New-Object -TypeName System.Net.WebClient
+    $client.DownloadFile($url, $path)
+}
+
+# Imported from https://github.com/jborean93/ansible-windows/tree/master/scripts
+Function Extract-Zip($zip, $dest) {
+    LogMessage -MessageType $DEBUG -Message "extracting '$zip' to '$dest'"
+    try {
+        Add-Type -AssemblyName System.IO.Compression.FileSystem > $null
+        $legacy = $false
+    } catch {
+        $legacy = $true
+    }
+
+    if ($legacy) {
+        $shell = New-Object -ComObject Shell.Application
+        $zip_src = $shell.NameSpace($zip)
+        $zip_dest = $shell.NameSpace($dest)
+        $zip_dest.CopyHere($zip_src.Items(), 1044)
+    } else {
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $dest)
+    }
+}
+
+# --- Main Script
+Push-Location
+Set-Location $PSScriptRoot
+$path = Get-Location
+$scriptName  = $MyInvocation.MyCommand.Name
+
+# set default log file if not specified
+if ($LogFile) {
+    $scriptLog = $LogFile
+}
+else {
+    $scriptLog = "$path\$scriptName.log"
+}
+
+Write-Debug "Setting log file to $scriptLog"
+
+LogMessage -MessageType $DEBUG -Message "Begin Run ********"
+
+if (-Not (Test-Path $scriptLog)) {
+    Write-Debug "$scriptLog does not exists. Creating new log file"
+    New-Item -Path $scriptLog -Confirm:$false -Force -ItemType File | Out-Null
+}
+
+LogMessage -MessageType $DEBUG -Message "Checking for version of Powershell currently installed"
+
+if ( $PSVersionTable.PSVersion.Major -lt 5) {
+    $verMessage = "Powershell version is " + $PSVersionTable.PSVersion + ", it will be updated to Version 5"
+    LogMessage -MessageType $DEBUG -Message $verMessage
+}
+else {
+    $verMessage =  "Powershell version is " + $PSVersionTable.PSVersion + " no need to upgrade"
+    LogMessage -MessageType $DEBUG -Message $verMessage
+    LogMessage($DEBUG, "End Run **********")
+    Pop-Location
+    Exit(0)
+}
+
+# Download required file
+$tmp_dir = "$path\wmf5-setup"
+
+if (Test-Path -Path $tmp_dir) {
+    LogMessage -MessageType $DEBUG -Message "Stale $tmp_dir exists. Delete it."
+    Remove-Item -Path $tmp_dir -Recurse -Confirm:$false -Force > $null
+}
+
+if (-not (Test-Path -Path $tmp_dir)) {
+    LogMessage -MessageType $DEBUG -Message "Creating $tmp_dir"
+    New-Item -Path $tmp_dir -ItemType Directory > $null
+}
+LogMessage -MessageType $DEBUG -Message "Calculating OS Version and Build"
+$os_version = [Version](Get-Item -Path "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
+LogMessage -MessageType $DEBUG -Message "Calculated os version: $os_version"
+$host_string = "$($os_version.Major).$($os_version.Minor)-$($env:PROCESSOR_ARCHITECTURE)"
+LogMessage -MessageType $DEBUG -Message "Calculated host string : $host_string"
+switch($host_string) {
+    "6.1-x86" {
+        $url = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win7-KB3191566-x86.zip"
+    }
+    "6.1-AMD64" {
+        $url = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win7AndW2K8R2-KB3191566-x64.zip"
+    }
+    "6.2-x86" {
+        $url = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1-KB3191564-x86.msu"
+    }
+    "6.2-AMD64" {
+        $url = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/W2K12-KB3191565-x64.msu"
+    }
+    "6.3-x86" {
+        $url = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1-KB3191564-x86.msu"
+    }
+    "6.3-AMD64" {
+        $url = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+    }
+}
+
+$filename = $url.Split("/")[-1]
+LogMessage -MessageType $DEBUG -Message "Downloading $filename from $url to $tmp_dir\$filename"
+
+Download-File -url $url -path "$tmp_dir\$filename"
+
+if ($filename -match '.zip$') {
+    LogMessage -MessageType $DEBUG -Message "update is a zip file"
+    Extract-Zip -zip "$tmp_dir\$filename" -dest $tmp_dir
+}
+elseif ($filename -match '.msu$') {
+    LogMessage -MessageType $DEBUG -Message "update is an msu file"
+}
+else {
+    LogMessage -MessageType $ERR -Message "update file format is not recognized. cannot update system. exiting"
+    LogMessage($DEBUG, "End Run **********")
+    Pop-Location
+    Exit(1)
+}
+
+$file = Get-Item -Path "$tmp_dir\*.msu"
+
+# Run Setup
+$exit_code = Run-Process -executable $file.FullName -arguments "/quiet /norestart"
+if ($exit_code -eq 3010) {
+    Write-Verbose "need to restart computer after$file install"
+    if ($SkipReboot) {
+        Write-Verbose "skip reboot is enabled. no reboot will be performed."
+    }
+    else {
+        if ($AutoReboot) {
+            Write-Verbose "performing autoreboot"
+            Restart-Computer -Confirm:$false
+        }
+        else {
+            Write-Verbose "getting user confirmation to reboot"
+            Restart-Computer -Confirm
+        }
+    }
+} elseif ($exit_code -ne 0) {
+    Write-Error -Message "failed to install $file exit code $exit_code"
+} else {
+    Write-Verbose -Message "$file install complete"
+}
+exit $exit_code
+
+LogMessage($DEBUG, "End Run **********")
+
+Pop-Location

--- a/scripts/Install-WMF5.vbs
+++ b/scripts/Install-WMF5.vbs
@@ -1,0 +1,322 @@
+' Installs Windows Management Framework 5
+Option Explicit
+
+' --- Constants
+Const MsgDebug = "DEBUG"
+Const MsgInfo = "INFO"
+Const MsgWarning = "WARNING"
+Const MsgError = "ERROR"
+Const ForReading = 1
+Const ForWriting = 2
+Const ForAppending = 8
+
+' --- Script Variables
+Dim wShellObj, fsObj, logFile, logFileHandle
+Dim powershellVersionRegistry, psVersionStr, psVersion
+Dim installWMF5, wmf5DownloadDIR, downloadURL, setupFile, mediaFolderObj, mediaFiles, file, msuFile, msuDataDIR, msuDataFolderObj, msuDataFiles, cabsToInstall, cabItemsToInstall, i, dismLogFile, fileDownloadRetryLimit, fileDownloadCount, fileDownloadSucceeded
+Dim objWMIService, strComputer, oss, os, architecture, osVersion, hostString
+
+powershellVersionRegistry = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine\PowerShellVersion"
+installWMF5 = True
+strComputer = "."
+fileDownloadRetryLimit = 5
+' ***** Function Declaration *****
+Function LogMessage( msgType, msg )
+    WScript.Echo Date & " " & Time & " " & msgType & " " & msg
+    logFileHandle.WriteLine Date & " " & Time & " " & msgType & " " & msg
+End Function
+
+Sub HTTPDownload( myURL, myPath )
+    Dim objFSO, objHTTP, strFile, dataStream
+    
+    Set objFSO = CreateObject( "Scripting.FileSystemObject" )
+    If objFSO.FolderExists( myPath ) Then
+        strFile = objFSO.BuildPath( myPath, Mid( myURL, InStrRev( myURL, "/" ) + 1 ) )
+    ElseIf objFSO.FolderExists( Left( myPath, InStrRev( myPath, "\" ) - 1 ) ) Then
+        strFile = myPath
+    Else
+        Call LogMessage(MsgError, "Target folder not found.")
+        Exit Sub
+    End If
+
+    call LogMessage(MsgDebug, "Starting file download")
+	' Enable Error Handling
+	On Error Resume Next
+	Err.Clear
+	call LogMessage(MsgDebug, "Creating Microsoft.XMLHTTP Object")
+    Set objHTTP = CreateObject( "Microsoft.XMLHTTP" )
+	
+	If Err.Number <> 0 Then
+		call LogMessage(MsgError, "Could not create Microsoft.XMLHTTP Object. Error Details: " & Err.Description)
+		Err.Clear
+	Else
+		call LogMessage(MsgDebug, "Microsoft.XMLHTTP Object created successfully")
+	End If
+		
+	Err.Clear
+	call LogMessage(MsgDebug, "Trying to open a GET request on " & myURL)	
+    objHTTP.Open "GET", myURL, False
+	
+	If Err.Number <> 0 Then
+		call LogMessage(MsgError, "Could not open GET on " & myURL & " Error Details: " & Err.Description)
+		Err.Clear
+	Else
+		call LogMessage(MsgDebug, "Successfully opened GET on " & myURL)
+	End If	
+	
+	Err.Clear
+	call LogMessage(MsgDebug, "Trying to issue Send on " & myURL)	    
+    objHTTP.Send
+    
+	If Err.Number <> 0 Then
+		call LogMessage(MsgError, "Could not issue Send on " & myURL & " Error Details: " & Err.Description)
+		Err.Clear
+	Else
+		call LogMessage(MsgDebug, "Successfully issued Send on " & myURL)
+	End If
+	
+    If objHTTP.Status = 200 Then
+		call LogMessage(MsgDebug, "HTTP Status Code is 200. Saving file data now.")
+		Err.Clear
+		Set dataStream = CreateObject("Adodb.Stream")
+	
+        With dataStream
+            .Type = 1
+            .Open
+            .Write objHTTP.responseBody
+            .SaveToFile strFile, 2
+        End With
+		call LogMessage(MsgDebug, "File data saved.")
+    Else
+        LogMessage MsgError, "Could not download file from " & myURL
+    End If
+    call LogMessage(MsgDebug, "Ending file download")
+	
+	' Disable Error Handling
+	On Error Goto 0
+End Sub
+
+Sub ExtractZipFile( zipFile, unzipDIR )
+    Dim shellObj, filesInZip
+    Call LogMessage(MsgDebug, "Extracting file " & zipFile & " to " & unzipDIR)
+    Set shellObj = CreateObject("Shell.Application")
+    Set filesInZip = shellObj.NameSpace(zipFile).Items()    
+    shellObj.NameSpace(unzipDIR).CopyHere filesInZip, 16
+    Set shellObj = Nothing
+    Set filesInZip =  Nothing
+    Call LogMessage(MsgDebug, "Extraction completed")
+End Sub
+
+Sub RunProcess( executable, arguments )
+    Dim process, p_stdout, p_stderr
+    Call LogMessage(MsgDebug, "Launching command " & executable & " with arguments: " & arguments)
+    Set process = wShellObj.Exec("cmd /c " & executable & " " & arguments)
+    p_stdout = process.Stdout.ReadAll
+    Call LogMessage(MsgDebug, "Command standard Output " & p_stdout)
+    p_stderr = process.StdErr.ReadAll
+    Call LogMessage(MsgDebug, "Command standard error " & p_stderr)
+End Sub
+
+Function ParsePkgInstallOrderFile( pkgFile )
+    Dim pkgFileHandle, line, pkgInstallOrderDictionary, lineParts
+    Call LogMessage(MsgDebug, "Parsing file " & pkgFile)
+    Set pkgInstallOrderDictionary = CreateObject("Scripting.Dictionary")
+    Set pkgFileHandle = fsObj.OpenTextFile( pkgFile, ForReading)
+    Do Until pkgFileHandle.AtEndOfStream
+        line = pkgFileHandle.ReadLine
+        Call LogMessage(MsgDebug, "Data - " & line)
+        If InStr(line, "=") > 0 Then            
+            lineParts = Split(line, "=")
+            If UBound(lineParts) = 1 Then
+                Call LogMessage(MsgDebug, "Adding to result hash: " & lineParts(0) & " - " & lineParts(1))
+                pkgInstallOrderDictionary.Add lineParts(0), lineParts(1)
+            Else
+                Call LogMessage(MsgWarning, "could not parse property " & line & " correctly")
+            End If
+        End If
+    Loop    
+	pkgFileHandle.Close
+    Set ParsePkgInstallOrderFile = pkgInstallOrderDictionary
+End Function
+
+' ***** Main Script **************
+' Create Log File
+Set wShellObj = WScript.CreateObject("WScript.Shell")
+logFile = wShellObj.CurrentDirectory & "\" & WScript.ScriptName & ".log"
+Set fsObj = WScript.CreateObject("Scripting.FileSystemObject")
+Set logFileHandle = fsObj.OpenTextFile(logFile, ForAppending, True)
+dismLogFile = wShellObj.CurrentDirectory & "\dism.log"
+
+Call LogMessage(MsgDebug, "Beginning Script")
+
+' Get WMF Version
+Call LogMessage(MsgDebug, "Checking for installed powershell version")
+
+On Error Resume Next
+psVersionStr = wShellObj.RegRead(powershellVersionRegistry)
+If Err.Number <> 0 Then
+    LogMessage MsgWarning, "Powershell is not installed on the system. Error Code = " & Err.Description
+    Err.Clear
+Else
+    Call LogMessage(MsgDebug, "Installed powershell version = " + psVersionStr)    
+    psVersion = Mid(psVersionStr,1,3)
+
+    If Err.Number <> 0 Then
+        LogMessage MsgWarning, "Could not convert Powershell version to number. Error Code = " & Err.Description
+        Err.Clear
+    Else
+        If psVersion >= 5 Then
+            Call LogMessage(MsgDebug, "Powershell version " & psVersion & " is already higher than 5.")
+            installWMF5 = False            
+        End If
+    End If
+End If
+On Error Goto 0
+
+If NOT installWMF5 Then
+    Call LogMessage(MsgDebug, "Ending Script as WMF5 is already installed")
+    ' Close Log File
+    logFileHandle.Close
+    WScript.Quit 0
+End If
+
+' Download required files
+wmf5DownloadDIR = wShellObj.CurrentDirectory & "\WMF5-Media"
+Call LogMessage(MsgDebug, "Checking for " & wmf5DownloadDIR)
+If fsObj.FolderExists(wmf5DownloadDIR) Then
+    Call LogMessage(MsgWarning, "Folder " & wmf5DownloadDIR & " already exists. Cleaning it up")
+    fsObj.DeleteFolder wmf5DownloadDIR, True
+End If
+
+Call LogMessage(MsgDebug, "Creating " & wmf5DownloadDIR)
+
+On Error Resume Next
+Err.Clear
+fsObj.CreateFolder wmf5DownloadDIR
+If Err.Number <> 0 Then
+    LogMessage MsgWarning, "Could not create folder " & wmf5DownloadDIR & " Error Code = " & Err.Description
+    Err.Clear
+    logFileHandle.Close
+    WScript.Quit 1
+End If
+On Error Goto 0
+
+' Calculate OS Version
+Call LogMessage(MsgDebug, "Calculating OS Version and Architecture using WMI")
+Set objWMIService = GetObject("winmgmts:{impersonationLevel=impersonate}!\\" & strComputer & "\root\cimv2")
+Set oss = objWMIService.ExecQuery ("Select * from Win32_OperatingSystem")
+
+For Each os in oss
+    osVersion = os.Version
+    architecture = os.OSArchitecture
+Next
+Call LogMessage(MsgDebug, "OS Version: " & osVersion & " and Architecture: " & architecture)
+
+If StrComp(architecture, "64-bit") = 0 Then
+    hostString = Mid(osVersion,1,3) & "-AMD64"
+Else
+    hostString = Mid(osVersion,1,3) & "-x86"
+End if
+Call LogMessage(MsgDebug, "Created host string " & hostString)
+
+Select case hostString:
+    case "6.1-x86"
+        downloadURL = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win7-KB3191566-x86.zip"
+    case "6.1-AMD64"
+        downloadURL = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win7AndW2K8R2-KB3191566-x64.zip"
+    case "6.2-x86"
+        downloadURL = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1-KB3191564-x86.msu"
+    case "6.2-AMD64"
+        downloadURL = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/W2K12-KB3191565-x64.msu"
+    case "6.3-x86"
+        downloadURL = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1-KB3191564-x86.msu"
+    case "6.3-AMD64"
+        downloadURL = "https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu"
+    case Else
+        LogMessage MsgWarning, "could not determine downloadURL"
+End Select
+
+Call LogMessage(MsgDebug, "Using downloadURL " & downloadURL)
+setupFile = Mid(downloadURL, InStrRev(downloadURL, "/")+1)
+Call LogMessage(MsgDebug, "Downloading setup file " & setupFile)
+
+fileDownloadCount = 0
+fileDownloadSucceeded = False
+Do Until fileDownloadSucceeded or fileDownloadCount > fileDownloadRetryLimit
+	fileDownloadCount = fileDownloadCount + 1
+	Call LogMessage(MsgDebug, "Download attempt - " & fileDownloadCount)
+	HTTPDownload downloadURL, wmf5DownloadDIR
+	If fsObj.FileExists(wmf5DownloadDIR & "\" & setupFile) Then
+		Call LogMessage(MsgDebug, "Successfully downloaded setup file " & wmf5DownloadDIR & "\" & setupFile)
+		fileDownloadSucceeded = True
+	End If	
+Loop
+
+If fsObj.FileExists(wmf5DownloadDIR & "\" & setupFile) Then
+    Call LogMessage(MsgDebug, "Successfully downloaded setup file " & wmf5DownloadDIR & "\" & setupFile)
+Else
+    Call LogMessage(MsgError, "Could not download setup file to " & wmf5DownloadDIR & "\" & setupFile)
+    logFileHandle.Close
+    WScript.Quit 1
+End if
+
+Call LogMessage(MsgDebug, "Checking if downloaded file needs extraction")
+if StrComp(Right(setupFile, 4), ".zip") = 0 Then
+    Call LogMessage(MsgDebug, "Downloaded file is a zip. Trying to extract it")
+    ExtractZipFile fsObj.GetAbsolutePathName(wmf5DownloadDIR & "\" & setupFile), fsObj.GetAbsolutePathName(wmf5DownloadDIR)
+Else
+    Call LogMessage(MsgDebug, "Downloaded file is not a zip. No further extraction needed")
+End if
+
+' Search of MSU file and extract it
+Call LogMessage(MsgDebug, "Checking for msu file in " & wmf5DownloadDIR)
+Set mediaFolderObj = fsObj.GetFolder(wmf5DownloadDIR)
+Set mediaFiles = mediaFolderObj.Files
+msuFile = ""
+For Each file in mediaFiles 
+    if StrComp(Right(file.Name,4), ".msu") = 0 Then
+        Call LogMessage(MsgDebug, "Found MSU file " & file.Name)
+        msuFile = file.Name
+    End If
+Next
+
+If Len(msuFile) > 0 Then
+    Call LogMessage(MsgDebug, "Processing MSU File " & wmf5DownloadDIR & "\" & msuFile)
+    msuDataDIR = wmf5DownloadDIR & "\msu-data"
+    RunProcess "wusa.exe", wmf5DownloadDIR & "\" & msuFile & " /extract:" & msuDataDIR
+Else
+    Call LogMessage(MsgError, "No MSU file found in " & wmf5DownloadDIR)
+    logFileHandle.Close
+    WScript.Quit 1
+End If
+
+' Run setup
+Call LogMessage(MsgDebug, "Searching for PkgInstallOrder.txt file within " & msuDataDIR)
+Set msuDataFolderObj = fsObj.GetFolder(msuDataDIR)
+Set msuDataFiles = msuDataFolderObj.Files
+
+For Each file in msuDataFiles
+    If StrComp(file.Name, "PkgInstallOrder.txt") = 0 Then
+        Call LogMessage(MsgDebug, "PkgInstallOrder.txt file exists. Parse file to get installation sequence")
+        Set cabsToInstall = ParsePkgInstallOrderFile(msuDataDIR & "\PkgInstallOrder.txt")    
+        Exit For    
+    Else
+        If StrComp(Right(file.Name,4), ".cab") = 0 and StrComp(file.Name, "WSUSSCAN.cab") <> 0  Then
+            Call LogMessage(MsgDebug, "Adding CAB file " & file.Name & " to installation list")
+            Set cabsToInstall = CreateObject("Scripting.Dictionary")
+            cabsToInstall.Add "0", file.Name
+        End If
+    End If
+Next
+
+Call LogMessage(MsgDebug, "processing cabs that need to be installed")
+cabItemsToInstall = cabsToInstall.Items
+For i = 0 To UBound(cabsToInstall.Items)
+    Call LogMessage(MsgDebug, "" & i+1 & " " & cabItemsToInstall(i))
+    RunProcess "dism.exe", "/Online /Add-Package /PackagePath:" & msuDataDIR & "\" & cabItemsToInstall(i) & " /Quiet /NoRestart /LogLevel:4 /LogPath:" & dismLogFile
+Next
+
+Call LogMessage(MsgDebug, "Ending Script. Check " & dismLogFile & " for details")
+
+' Close Log File
+logFileHandle.Close

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -101,3 +101,56 @@ $file = "$env:SystemDrive\temp\Install-WMF3Hotfix.ps1"
 (New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
 powershell.exe -ExecutionPolicy ByPass -File $file -Verbose
 ```
+
+## Install-WMF5.ps1
+
+The script will install the [Windows Management Framework 5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616). 
+
+**NOTE: This script WILL NOT run with using remote invocations, because of Microsoft's limitation with running Windows Updates remotely**
+
+The script will;
+1. Detect if running on PS version 3.0 and exit if it is not
+2. Check current version of Powershell installed. If the version is 5 or greater than exit
+3. Download WMF 5 from Microsoft server's based on the OS version
+4. Extract the .msu file from the downloaded hotfix
+5. Install the .msu silently
+6. Detect if a reboot is required and prompt whether the user wants to restart
+
+Once the install is complete, if the install process returns an exit
+code of `3010`, it will ask the user whether to restart the computer now
+or whether it will be done later.
+
+To run this script, the following commands can be run:
+
+```PowerShell
+$url = "https://raw.githubusercontent.com/junaidali/ansible-windows/master/scripts/Install-WMF5.ps1"
+$file = "$env:SystemDrive\temp\Install-WMF5.ps1"
+
+(New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
+powershell.exe -ExecutionPolicy ByPass -File $file -Verbose
+```
+
+
+## Install-WMF5.vbs
+The script will install the [Windows Management Framework 5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616). 
+
+**NOTE: This script WILL RUN with using remote invocations as it uses dism to install the cab patches rather than wusa.exe**
+
+The script will;
+1. Check current version of Powershell installed. If the version is 5 or greater than exit
+2. Download WMF 5 from Microsoft server's based on the OS version
+3. Extract the .msu file from the downloaded hotfix
+4. Extract the .msu file to generate cabs
+5. Lookup PkgInstallOrder.txt within the extracted files. If it is found use the list of cabs in that file and install them sequentially using dism.exe
+6. If PkgInstallOrder.txt does not exists within the extracted files, use the cab file not named WSUSSCAN.CAB with the directory and install it using dism.exe
+6. Does not force reboot. Make sure to reboot after successful completion. This is by design, as the script will be used along with external provisioning tools like Terraform or Configuration tools like ansible that should be handling reboots.
+
+To run this script, the following commands can be run:
+
+```PowerShell
+$url = "https://raw.githubusercontent.com/junaidali/ansible-windows/master/scripts/Install-WMF5.vbs"
+$file = "$env:SystemDrive\temp\Install-WMF5.ps1"
+
+(New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
+cscript.exe $file
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,7 +143,10 @@ The script will;
 4. Extract the .msu file to generate cabs
 5. Lookup PkgInstallOrder.txt within the extracted files. If it is found use the list of cabs in that file and install them sequentially using dism.exe
 6. If PkgInstallOrder.txt does not exists within the extracted files, use the cab file not named WSUSSCAN.CAB with the directory and install it using dism.exe
-6. Does not force reboot. Make sure to reboot after successful completion. This is by design, as the script will be used along with external provisioning tools like Terraform or Configuration tools like ansible that should be handling reboots.
+6. Does not force reboot. 
+
+
+**NOTE: Make sure to reboot after successful completion. This is by design, as the script will be used along with external provisioning tools like Terraform or Configuration tools like ansible that should be handling reboots.**
 
 To run this script, the following commands can be run:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -152,7 +152,7 @@ To run this script, the following commands can be run:
 
 ```PowerShell
 $url = "https://raw.githubusercontent.com/junaidali/ansible-windows/master/scripts/Install-WMF5.vbs"
-$file = "$env:SystemDrive\temp\Install-WMF5.ps1"
+$file = "$env:SystemDrive\temp\Install-WMF5.vbs"
 
 (New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)
 cscript.exe $file


### PR DESCRIPTION
Thanks @jborean93  for creating these extremely useful scripts. I've added two new scripts for installing windows management framework 5.1. The Install-WMF5.ps1 powershell script is for local installation of WMF 5.1 as Microsoft does not support running it over remote connection. To resolve this issue I've created Install-WMF5.vbs which is native vbscript that can be run on machines that don't have PowerShell installed or is corrupted.